### PR TITLE
Avoid omitting image field

### DIFF
--- a/api/v1alpha1/nififn_types.go
+++ b/api/v1alpha1/nififn_types.go
@@ -65,7 +65,7 @@ type NiFiFnSpec struct {
 	FlowXMLPath string `json:"flowXmlPath,omitempty"`
 
 	// +kubebuilder:validation:Pattern=.+:.+
-	Image string `json:"-"`
+	Image string `json:"image,omitempty"`
 
 	MaterializeContent bool `json:"materializeContent,omitempty"`
 

--- a/config/crd/bases/nififn.nifi-stateless.b23.io_nififns.yaml
+++ b/config/crd/bases/nififn.nifi-stateless.b23.io_nififns.yaml
@@ -67,6 +67,9 @@ spec:
               type: integer
             flowXmlPath:
               type: string
+            image:
+              pattern: .+:.+
+              type: string
             materializeContent:
               type: boolean
             parameters:

--- a/config/deploy/nifi-stateless-operator.yaml
+++ b/config/deploy/nifi-stateless-operator.yaml
@@ -72,6 +72,8 @@ spec:
               type: integer
             flowXmlPath:
               type: string
+            image:
+              type: string
             materializeContent:
               type: boolean
             parameters:

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
Container image field is omitted inside the nififn_types.go file. This leads to ignoring the image and it's impossible to deploy the k8s job with another docker image of nifi-stateless. This fix resolves this problem.

Issue ref: https://github.com/B23admin/nifi-stateless-operator/issues/11